### PR TITLE
Gate all uses of Contexts.SharedInstance behind a #define

### DIFF
--- a/Plugins/EntitasRedux.Core.Plugins/Cleanup/CodeGenerators/ContextCleanupFeatureGenerator.cs
+++ b/Plugins/EntitasRedux.Core.Plugins/Cleanup/CodeGenerators/ContextCleanupFeatureGenerator.cs
@@ -58,10 +58,12 @@ namespace EntitasRedux.Core.Plugins
 
 public class ${ContextName}CleanupFeature : Feature
 {
+	#if !ENTITAS_REDUX_NO_SHARED_CONTEXT
 	public ${ContextName}CleanupFeature() : base()
 	{
 		AddSystems(Contexts.SharedInstance.${ContextName});
 	}
+	#endif
 
 	public ${ContextName}CleanupFeature(IContext<${ContextName}Entity> context) : base()
 	{

--- a/Plugins/EntitasRedux.Core.Plugins/Cleanup/CodeGenerators/ContextCleanupSystemsGenerator.cs
+++ b/Plugins/EntitasRedux.Core.Plugins/Cleanup/CodeGenerators/ContextCleanupSystemsGenerator.cs
@@ -58,11 +58,13 @@ namespace EntitasRedux.Core.Plugins
 
 public class ${ContextName}CleanupSystems : JCMG.EntitasRedux.Systems
 {
+	#if !ENTITAS_REDUX_NO_SHARED_CONTEXT
 	public ${ContextName}CleanupSystems() : base()
 	{
 		var context = Contexts.SharedInstance.${ContextName};
 {AddCleanupSystems}
 	}
+	#endif
 
 	public ${ContextName}CleanupSystems(IContext<${ContextName}Entity> context) : base()
 	{

--- a/Plugins/EntitasRedux.Core.Plugins/Contexts/CodeGenerators/ContextsGenerator.cs
+++ b/Plugins/EntitasRedux.Core.Plugins/Contexts/CodeGenerators/ContextsGenerator.cs
@@ -56,6 +56,14 @@ namespace EntitasRedux.Core.Plugins
 	#endif
 
 	#if !ENTITAS_REDUX_NO_SHARED_CONTEXT
+	/// <summary>
+	/// A globally-accessible singleton instance of <see cref=""Contexts""/>. Instantiated
+	/// the first time its <see langword=""get""/> property is used.
+	/// </summary>
+	/// <remarks>
+	/// If your project forbids global singletons like this one, add a <c>#define</c> named <c>ENTITAS_REDUX_NO_SHARED_CONTEXT</c>
+	/// to its build settings. Doing so will remove this property to prevent accidental use.
+	/// </remarks>
 	public static Contexts SharedInstance
 	{
 		get

--- a/Plugins/EntitasRedux.Core.Plugins/Contexts/CodeGenerators/ContextsGenerator.cs
+++ b/Plugins/EntitasRedux.Core.Plugins/Contexts/CodeGenerators/ContextsGenerator.cs
@@ -33,7 +33,7 @@ namespace EntitasRedux.Core.Plugins
 		private const string TEMPLATE =
 @"public partial class Contexts : JCMG.EntitasRedux.IContexts
 {
-	#if UNITY_EDITOR
+	#if UNITY_EDITOR && !ENTITAS_REDUX_NO_SHARED_CONTEXT
 
 	static Contexts()
 	{
@@ -55,6 +55,7 @@ namespace EntitasRedux.Core.Plugins
 
 	#endif
 
+	#if !ENTITAS_REDUX_NO_SHARED_CONTEXT
 	public static Contexts SharedInstance
 	{
 		get
@@ -70,6 +71,7 @@ namespace EntitasRedux.Core.Plugins
 	}
 
 	static Contexts _sharedInstance;
+	#endif
 
 ${contextPropertiesList}
 


### PR DESCRIPTION
# Description

I don't use `Contexts.SharedInstance` in my game, because I rely heavily on dependency injection instead of singletons. However, I don't want to risk instantiating `Contexts.SharedInstance` by mistake, as that could lead to a very frustrating and confusing debugging session.

Hence, I wrapped all built-in uses of the generated field in `#if !ENTITAS_REDUX_NO_SHARED_CONTEXT`. To disable `Contexts.SharedInstance` in your project, define that symbol. Otherwise, existing code will continue to work as-is.

# How Has This Been Tested?

I added a local build of the plugin to my own project. Works like a charm.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
