### PR TITLE
Fix #56, but for real

### DIFF
--- a/Plugins/EntitasRedux.Core.Plugins/EntityIndex/CodeGenerators/EntityIndexGenerator.cs
+++ b/Plugins/EntitasRedux.Core.Plugins/EntityIndex/CodeGenerators/EntityIndexGenerator.cs
@@ -83,7 +83,6 @@ ${getIndices}
 			var indexConstants = string.Join(
 				"\n",
 				data
-					.Where(x => !x.IsCustom())
 					.Select(
 						d => INDEX_CONSTANTS_TEMPLATE
 							.Replace(

--- a/Plugins/EntitasRedux.Core.Plugins/EntityIndex/CodeGenerators/EntityIndexGenerator.cs
+++ b/Plugins/EntitasRedux.Core.Plugins/EntityIndex/CodeGenerators/EntityIndexGenerator.cs
@@ -75,8 +75,7 @@ ${getIndices}
 @"	public static ${ReturnType} ${MethodName}(this ${ContextName}Context context, ${methodArgs})
 	{
 		return ((${IndexType})(context.GetEntityIndex(Contexts.${IndexName}))).${MethodName}(${args});
-	}
-";
+	}";
 
 		private CodeGenFile[] GenerateEntityIndices(EntityIndexData[] data)
 		{

--- a/Plugins/EntitasRedux.Core.Plugins/EntityIndex/DataProviders/EntityIndexDataProvider.cs
+++ b/Plugins/EntitasRedux.Core.Plugins/EntityIndex/DataProviders/EntityIndexDataProvider.cs
@@ -144,7 +144,9 @@ namespace EntitasRedux.Core.Plugins
 					contextType.GetFullTypeName().ShortTypeName().RemoveContextSuffix()
 				});
 
-			var getMethods = contextType.GetAllMembers()
+			var getMethods = cachedNamedTypeSymbol
+				.NamedTypeSymbol
+				.GetAllMembers()
 				.Where(method => method.HasAttribute<EntityIndexGetMethodAttribute>())
 				.Select(
 					method => new MethodData(

--- a/Unity/Assets/ExampleContent/Generated/Contexts.cs
+++ b/Unity/Assets/ExampleContent/Generated/Contexts.cs
@@ -75,6 +75,7 @@ public partial class Contexts : JCMG.EntitasRedux.IContexts
 
 public partial class Contexts
 {
+	public const string ExampleContentVisualDebuggingCustomIndexesColorPositionEntityIndex = "ExampleContentVisualDebuggingCustomIndexesColorPositionEntityIndex";
 	public const string IndexedEntity = "IndexedEntity";
 	public const string IndexedPrimary = "IndexedPrimary";
 
@@ -97,7 +98,10 @@ public partial class Contexts
 
 public static class ContextsExtensions
 {
-
+	public static System.Collections.Generic.HashSet<VisualDebugEntity> GetColorEntitiesAtPosition(this VisualDebugContext context, ExampleContent.VisualDebugging.IntVector2 pos)
+	{
+		return ((ExampleContent.VisualDebugging.CustomIndexes.ColorPositionEntityIndex)(context.GetEntityIndex(Contexts.ExampleContentVisualDebuggingCustomIndexesColorPositionEntityIndex))).GetColorEntitiesAtPosition(pos);
+	}
 
 	public static System.Collections.Generic.HashSet<VisualDebugEntity> GetEntitiesWithIndexedEntity(this VisualDebugContext context, int id)
 	{


### PR DESCRIPTION
# Description

Extension methods for custom entity indexes weren't being applied to the generated `Contexts` class. This PR fixes that.

Fixes #56

# How Has This Been Tested?

I ran the revised plugin on the sample code in `Assets/ExampleContent` and reviewed output in `Contexts`. Once I got it correct, I committed it alongside the code for the bugfix.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **Nothing to comment**
- [x] I have made corresponding changes to the documentation **Nothing to document**
- [x] My changes generate no new warnings
